### PR TITLE
Working

### DIFF
--- a/launch_execute_learning.sh
+++ b/launch_execute_learning.sh
@@ -14,15 +14,17 @@
 # 3) array of different numbers of defects to run with
 # 4) array of repetitions numbers for each defect number
 # 5) array of iterations (proposals) numbers for each defect numbers
+# 6) proportion (as float) of data values from start to use for training; 1 means use all  
 # note:
 # 4) and 5) either have to be same length as 3),
 # or length 1 if same settings to be used for each defect number
 # but in each case must be arrays!  
 target_csv="Witnessing_Fig4b.csv"
-experiment_name="quick-test"
+experiment_name="250501-subset-learning-4"
 defects_numbers=(1)
 repetitions_numbers=(2)
-iterations_numbers=(2000)
+iterations_numbers=(5000)
+proportion_training=0.2
 
 
 # execution:
@@ -52,7 +54,7 @@ for i in ${!defects_numbers[@]}; do
     
     for ((rep=1; rep<=repetitions_number; rep++)); do
 	echo launching for $defects_number defects repetition no. $rep
-	nohup python execute_learning.py "$target_csv" "$experiment_name" "$defects_number" "$rep" "$iterations_number"  </dev/null &>"$experiment_name"_D"$defects_number"_R"$rep"_prog.txt &
+	nohup python execute_learning.py "$target_csv" "$experiment_name" "$defects_number" "$rep" "$iterations_number" "$proportion_training"  </dev/null &>"$experiment_name"_D"$defects_number"_R"$rep"_prog.txt &
 	done
 done
 

--- a/launch_sort_by_clusters.sh
+++ b/launch_sort_by_clusters.sh
@@ -14,9 +14,9 @@
 
 
 
-experiment_name="250425-Wit-4b-grey-batch"
-defects_number=2
-clusters_count=7
+experiment_name="combined-"
+defects_number=1
+clusters_count=6
 
 # just turn these into arrays as well and put in one more outer loop... quick stuff
 

--- a/learning_chain.py
+++ b/learning_chain.py
@@ -327,6 +327,10 @@ class LearningChain:
             # note: proposal not modified by this
             proposal, possible_modifications_reverse_type = self.step(proposal, self.complementary_step(next_step), update = False)
             
+            # if no reversal possible, skip to next proposal iteration:
+            # note: every step should be reversible - this should only ever be triggered when proposal gets killed by filter
+            if not bool(possible_modifications_reverse_type): continue
+            
             # overall probabilities of making this step and of then reversing it:
             p_there = self.next_step_probabilities_dict[next_step]/possible_modifications_chosen_type
             p_back = self.next_step_probabilities_dict[self.complementary_step(next_step)]/possible_modifications_reverse_type


### PR DESCRIPTION
found and fixed bug in learning chains run method - ocassional division by zero error when evaluating reversal probability, cause was filter sometimes removing proposal and hence no reversal options; now skipping to next proposal iteration if no reversal options; this should only ever occur if proposal is killed by filter, otherwise all steps should be reversible, this is assumed implicitly with no futher checks